### PR TITLE
Pc.better naming

### DIFF
--- a/ruleskit/rule.py
+++ b/ruleskit/rule.py
@@ -79,6 +79,8 @@ class Rule(ABC):
         if activation is not None and condition is None:
             raise ValueError("Condition can not be None if activation is not None")
 
+        self._name = None
+
         self._condition: Optional[Condition] = condition
         self._activation: Optional[Activation] = activation
         self._thresholds: Optional[Thresholds] = self.__class__.THRESHOLDS


### PR DESCRIPTION
* Fix: there was an error when doing 'rulset_1 += ruleset_2' : if ruleset_1 had no rules, then the rule type of ruleset_2 was not saved in the resulting ruleset. Now it is.
* New: rules can now have a name (rule._name), set when saving a ruleset as their index in the resulting csv. When loading a ruleset, this same index is used to set the rules names.
* chg: rule selection nowreturns a sorted ruleset